### PR TITLE
Handle registration with partner coupon from drive web

### DIFF
--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -168,7 +168,7 @@ UsersRouter.prototype.createUser = function (req, res, next) {
         return next(err);
       }
 
-      user.maxSpaceBytes = 1024 * 1024 * 1024 * 10;
+      user.maxSpaceBytes = req.body.maxSpaceBytes || 1024 * 1024 * 1024 * 10;
       user.activated = true;
 
       self.analytics.track({


### PR DESCRIPTION
# Dealify Integration
It registers users that bought an Internxt license from dealify.

Given a coupon code, these users will be able to register. This code is only valid for one email account and can only be redeemed once.

### What has been done?
Adds maxSpaceBytes when registering a user with a partner coupon.

### Test
- [x] Registers and updates the maxSpaceBytes with the normal flow.
- [x] Register and updates the maxSpaceBytes when a client buys a partner license.