### PR TITLE
[INFRA-101]:feat/add-delete-buckets-for-non-existing-user

### DIFF
--- a/bin/cleaner/delete-buckets-for-non-existing-users.js
+++ b/bin/cleaner/delete-buckets-for-non-existing-users.js
@@ -144,18 +144,13 @@ const checkBucket = (bucket, nextBucket) => {
 };
 
 function deleteBucketsWithNonExistingUsers(cb) {
-
-  let findConditions = {};
+  const filter = {};
   if (startFromBucket) {
-    findConditions.where = {
-      id: {
-        $gte: startFromBucket,
-      },
-    };
+    filter.id = { $gte: startFromBucket };
   }
 
   const cursor = BucketModel
-    .find(findConditions)
+    .find(filter)
     .sort({ _id: 1 })
     .cursor();
 


### PR DESCRIPTION
Deletes all buckets, bucket entries, frames, pointers of users who do not appear in the SQL db.

Also enqueues a message so that the network worker will make sure to delete the shard from S3

Missing:
- ~wait for connection to queue to begin~