### PR TITLE
[_]: fix/simplify-space-used-query

### DIFF
--- a/lib/server/routes/frames.js
+++ b/lib/server/routes/frames.js
@@ -472,63 +472,23 @@ FramesRouter.prototype.getFrameById = function (req, res, next) {
   });
 };
 
-function getStorageUsage(storage, user) {
-  const Bucket = storage.models.Bucket;
+async function getStorageUsage(storage, user) {
+  const { Frame } = storage.models;
 
-  return new Promise((resolve, reject) => {
-    var agg = Bucket.aggregate([
-      {
-        $match: {
-          user: user
-        }
-      },
-      {
-        $lookup: {
-          from: 'bucketentries',
-          localField: '_id',
-          foreignField: 'bucket',
-          as: 'join1'
-        }
-      },
-      {
-        $unwind: {
-          path: '$join1'
-        }
-      },
-      {
-        $lookup: {
-          from: 'frames',
-          localField: 'join1.frame',
-          foreignField: '_id',
-          as: 'join2'
-        }
-      },
-      {
-        $unwind: {
-          path: '$join2'
-        }
-      },
-      {
-        $project: {
-          _id: '$join2._id',
-          user: '$join2.user',
-          size: '$join2.size'
-        }
-      },
-      {
-        $group: {
-          _id: '$user',
-          total: { $sum: '$size' }
-        }
+  return Frame.aggregate([
+    {
+      $match: {
+        user,
+        locked: true
       }
-    ]).cursor({ batchSize: 1000 }).exec();
-
-    agg.next().then(data => {
-      resolve(data);
-    }).catch(err => {
-      reject({ message: 'Error', reason: err });
-    });
-  });
+    },
+    {
+      $group: {
+        _id: '$user',
+        total: { $sum: '$size' }
+      }
+    }
+  ]).cursor().exec().next();
 }
 
 function getStorageLimit(storage, user) {
@@ -553,22 +513,13 @@ function getStorageLimit(storage, user) {
   });
 }
 
-function userHasFreeSpaceLeft(storage, user) {
-  return new Promise((resolve) => {
-    getStorageLimit(storage, user).then(limit => {
-      const maxSpaceBytes = limit.maxSpaceBytes;
-      getStorageUsage(storage, user).then(usage => {
-        const usedSpaceBytes = usage ? usage.total : 0;
-        // If !maxSpaceBytes models are not updated. Consider no limit due to this variable.
-        resolve({ canUpload: !maxSpaceBytes ? true : usedSpaceBytes < maxSpaceBytes });
-      }).catch(err => {
-        resolve({ canUpload: false, error: err.message });
-      });
+async function userHasFreeSpaceLeft(storage, user) {
+  const { maxSpaceBytes } = await getStorageLimit(storage, user);
+  const usage = await getStorageUsage(storage, user);
+  const usedSpaceBytes = (usage && usage.total) || 0;
 
-    }).catch(err => {
-      resolve({ canUpload: false, error: err.message });
-    });
-  });
+  // If !maxSpaceBytes models are not updated. Consider no limit due to this variable.
+  return { canUpload: !maxSpaceBytes ? true : usedSpaceBytes < maxSpaceBytes };
 }
 
 FramesRouter.prototype.getStorageUsage = function (req, res) {


### PR DESCRIPTION
- Replaces the savage query used for calculating used storage (sometimes lasts 100 seconds, now lasts 100-200ms), making the space used calculation much more efficient.
- Refactors `getStorageUsage`