### PR TITLE
[_]: hotfix/wrong-log-pointer-id

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1412,7 +1412,7 @@ BucketsRouter.prototype.deletePointers = async function (pointers) {
     }
 
     pointer.remove().catch((err) => {
-      log.error('deletePointers: Error removing pointer %s: %s', pointer._id, err.message);
+      log.error('deletePointers: Error removing pointer %s: %s', pointerId, err.message);
     });
   }
 };


### PR DESCRIPTION
- Logs pointer id from the stored value in a variable

- Avoids printing pointer id from a removed data structure