### PR TITLE
[WT-228]: Refactor/remove password reset token

### DIFF
--- a/lib/apispec.json
+++ b/lib/apispec.json
@@ -7,12 +7,8 @@
   "host": "api.internxt.com",
   "basePath": "/",
   "schemes": ["https"],
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
   "securityDefinitions": {
     "basic": {
       "type": "basic",
@@ -125,7 +121,7 @@
                   },
                   "protocol": {
                     "description": "Protocol version this contact is running",
-                    "type" : "string",
+                    "type": "string",
                     "example": "0.7.0"
                   }
                 }
@@ -176,7 +172,7 @@
                 },
                 "protocol": {
                   "description": "Protocol version this contact is running",
-                  "type" : "string",
+                  "type": "string",
                   "example": "0.7.0"
                 }
               }
@@ -242,58 +238,6 @@
       }
     },
     "/users/{email}": {
-      "patch": {
-        "tags": ["users"],
-        "summary": "Requests the reset of the account password",
-        "parameters": [
-          {
-            "name": "email",
-            "in": "path",
-            "type": "string",
-            "description": "The email address of the account for password reset (yours)",
-            "required": true
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "properties": {
-                "password": {
-                  "type": "string",
-                  "description": "Hex encoded SHA-256 hash of the desired password"
-                },
-                "redirect": {
-                  "type": "string",
-                  "description": "Optional redirect URL for successful deletion"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Account password reset email sent",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "email": {
-                  "type": "string",
-                  "example": "hello@internxt.com"
-                },
-                "created": {
-                  "type": "string",
-                  "example": "2016-03-04T17:01:02.629Z"
-                },
-                "activated": {
-                  "type": "boolean",
-                  "example": true
-                }
-              }
-            }
-          }
-        }
-      },
       "delete": {
         "tags": ["users"],
         "summary": "Requests the deletion of the account",
@@ -391,7 +335,7 @@
       "post": {
         "tags": ["users"],
         "summary": "Sends the user an activation email for reactivating a disabled account",
-         "parameters": [
+        "parameters": [
           {
             "name": "token",
             "in": "path",
@@ -1159,7 +1103,7 @@
             "schema": {
               "type": "object",
               "properties": {
-               "pubkeys": {
+                "pubkeys": {
                   "type": "array",
                   "items": {
                     "type": "string",

--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -359,7 +359,9 @@ UsersRouter.prototype.destroyUser = function (req, res, next) {
   const redirect = req.query.redirect;
 
   if (req.user.configuration && req.user.configuration.disableDeactivation) {
-    return next(new errors.ConflictError('This account has the deactivation disabled'));
+    return next(
+      new errors.ConflictError('This account has the deactivation disabled')
+    );
   }
 
   if (!deactivator || !redirect) {
@@ -399,7 +401,10 @@ UsersRouter.prototype.destroyUser = function (req, res, next) {
               email: user.email,
             },
           ],
-          dynamic_template_data: { email: user.email, deletetion_url: redirect },
+          dynamic_template_data: {
+            email: user.email,
+            deletetion_url: redirect,
+          },
         },
       ],
       template_id: self.config.mailer.sendgrid.delete_template_id,
@@ -471,69 +476,6 @@ UsersRouter.prototype.confirmDestroyUser = function (req, res, next) {
         }
       }
     );
-  });
-};
-
-/**
- * Creates a password reset token
- * @param {http.IncomingMessage} req
- * @param {http.ServerResponse} res
- * @param {Function} next
- */
-UsersRouter.prototype.createPasswordResetToken = function (req, res, next) {
-  const self = this;
-  const User = this.storage.models.User;
-
-  User.findOne({ _id: req.params.id }, function (err, user) {
-    if (err) {
-      return next(new errors.InternalError(err.message));
-    }
-
-    if (!user) {
-      return next(new errors.NotFoundError('User not found'));
-    }
-
-    if (user.configuration && user.configuration.disableResetPassword) {
-      return next(new errors.ConflictError('This user has the password reset disabled'));
-    }
-
-    user.resetter = crypto.randomBytes(256).toString('hex');
-
-    user.save(function (err) {
-      if (err) {
-        return next(new errors.InternalError(err.message));
-      }
-
-      let profile = self.config.server.public || self.config.server;
-      let host = profile.host;
-      let port =
-        [443, 80].indexOf(profile.port) === -1 ? ':' + profile.port : '';
-      let proto =
-        self.config.server.ssl &&
-        self.config.server.ssl.cert &&
-        self.config.server.ssl.key
-          ? 'https:'
-          : 'http:';
-
-      self.mailer.dispatchSendGrid(
-        user.email,
-        'reset',
-        {
-          token: user.resetter,
-          redirect: req.body.redirect,
-          url: req.body.url || proto + '//' + host + port,
-        },
-        function (err) {
-          if (err) {
-            log.error('failed to send reset email, reason: %s', err.message);
-
-            return next(new errors.InternalError(err.message));
-          }
-
-          return res.status(200).send(user.toObject());
-        }
-      );
-    });
   });
 };
 
@@ -714,13 +656,6 @@ UsersRouter.prototype._definitions = function () {
       '/deactivations/:token',
       this.getLimiter(limiter(5)),
       this.confirmDestroyUser,
-    ],
-    [
-      'PATCH',
-      '/users/:id',
-      this.getLimiter(limiter(1)),
-      rawbody,
-      this.createPasswordResetToken,
     ],
     [
       'POST',


### PR DESCRIPTION
Endpoint for password reset token is not used in:
- drive-server-wip
- sdk
- drive-web
- bridge
- drive-server
- inxt-js

It is safe to remove. Fixes first part of securitum issue. 