### PR TITLE
[WT-228]: refactor/ remove confirm password reset endpoint

### DIFF
--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -538,76 +538,6 @@ UsersRouter.prototype.createPasswordResetToken = function (req, res, next) {
 };
 
 /**
- * Confirms and applies the password reset
- * @param {http.IncomingMessage} req
- * @param {http.ServerResponse} res
- * @param {Function} next
- */
-UsersRouter.prototype.confirmPasswordReset = function (req, res, next) {
-  const User = this.storage.models.User;
-
-  // NB: Mitigate timing attack
-  // NB: - attempt to make non-lookup-responses take similar
-  // NB: - amounts of time as lookup-responses
-  User.count({}, function (err, count) {
-    let rand = Math.floor(Math.random() * count);
-
-    function nextPlusTime(value) {
-      User.findOne({})
-        .skip(rand)
-        .exec(function () {
-          // do nothing with this record
-          next(value);
-        });
-    }
-
-    try {
-      assert(Buffer(req.body.password, 'hex').length * 8 === 256);
-    } catch (err) {
-      return next(
-        new errors.BadRequestError('Password must be hex encoded SHA-256 hash')
-      );
-    }
-
-    try {
-      assert(Buffer(req.params.token, 'hex').length === 256);
-    } catch (err) {
-      return nextPlusTime(
-        new Error('Resetter must be hex encoded 256 byte string')
-      );
-    }
-
-    User.findOne({ resetter: req.params.token }, function (err, user) {
-      if (err) {
-        return next(new errors.InternalError(err.message));
-      }
-
-      if (!user) {
-        return next(new errors.NotFoundError('User not found'));
-      }
-
-      user.hashpass = crypto
-        .createHash('sha256')
-        .update(req.body.password)
-        .digest('hex');
-      user.resetter = null;
-
-      user.save(function (err) {
-        if (err) {
-          return next(new errors.InternalError(err.message));
-        }
-
-        if (req.query.redirect) {
-          res.redirect(req.query.redirect);
-        } else {
-          res.send(user.toObject());
-        }
-      });
-    });
-  });
-};
-
-/**
  * Get user activation info
  * @param {http.IncomingMessage} req
  * @param {http.ServerResponse} res
@@ -721,13 +651,6 @@ UsersRouter.prototype._definitions = function () {
       this.getLimiter(limiter(1)),
       rawbody,
       this.createPasswordResetToken,
-    ],
-    [
-      'POST',
-      '/resets/:token',
-      rawbody,
-      this.getLimiter(limiter(5)),
-      this.confirmPasswordReset,
     ],
     [
       'GET',


### PR DESCRIPTION
Endpoint to confirm password reset  is not used in:

- drive-server-wip
- sdk
- drive-web
- bridge
- drive-server
- inxt-js

It is therefore safe to remove. Fixes second part of securitum issue.