### PR TITLE
[PB-1142]: feat/break-email-dependency

### DIFF
--- a/lib/core/buckets/MongoDBBucketsRepository.ts
+++ b/lib/core/buckets/MongoDBBucketsRepository.ts
@@ -23,7 +23,7 @@ export class MongoDBBucketsRepository implements BucketsRepository {
   }
 
   async findByUser(userId: string, limit: number, skip: number): Promise<Bucket[]> {
-    const buckets = await this.model.find({ user: userId }).skip(skip).limit(limit).exec();
+    const buckets = await this.model.find({ userId }).skip(skip).limit(limit).exec();
 
     return buckets;
   }
@@ -48,9 +48,9 @@ export class MongoDBBucketsRepository implements BucketsRepository {
     return formatFromMongoToBucket(rawModel);
   }
 
-  destroyByUser(userId: string): Promise<void> {
+  destroyByUser(userId: Bucket['userId']): Promise<void> {
     return this.model.deleteMany({
-      user: userId,
+      userId,
     });
   }
 

--- a/lib/core/buckets/Repository.ts
+++ b/lib/core/buckets/Repository.ts
@@ -1,11 +1,10 @@
-import { User } from '../users/User';
 import { Bucket } from './Bucket';
 
 export interface BucketsRepository {
   findOne(where: Partial<Bucket>): Promise<Bucket | null>;
-  findByUser(userId: User['id'], limit: number, skip: number): Promise<Bucket[]>;
+  findByUser(userId: Bucket['userId'], limit: number, skip: number): Promise<Bucket[]>;
   findByIds(ids: Bucket['id'][]): Promise<Bucket[]>;
   find(where: Partial<Bucket>): Promise<Bucket[]>;
-  destroyByUser(userId: User['id']): Promise<void>;
+  destroyByUser(userId: Bucket['userId']): Promise<void>;
   removeAll(where: Partial<Bucket>): Promise<void>;
 }

--- a/lib/core/buckets/usecase.ts
+++ b/lib/core/buckets/usecase.ts
@@ -655,13 +655,13 @@ export class BucketsUsecase {
     return newShard;
   } 
 
-  async listByUserId(userId: User['id'], limit: number, offset: number): Promise<Bucket[]> {
+  async listByUserId(userId: User['uuid'], limit: number, offset: number): Promise<Bucket[]> {
     const buckets = await this.bucketsRepository.findByUser(userId, limit, offset);
 
     return buckets;
   }
 
-  async destroyByUser(userId: User['id']) {
+  async destroyByUser(userId: User['uuid']) {
     await this.bucketsRepository.destroyByUser(userId);
   }
 }

--- a/lib/core/frames/MongoDBFramesRepository.ts
+++ b/lib/core/frames/MongoDBFramesRepository.ts
@@ -1,4 +1,3 @@
-import { User } from '../users/User';
 import { Frame } from './Frame';
 import { FramesRepository } from './Repository';
 

--- a/lib/core/users/MongoDBUsersRepository.ts
+++ b/lib/core/users/MongoDBUsersRepository.ts
@@ -52,6 +52,12 @@ export class MongoDBUsersRepository implements UsersRepository {
     return users.map(formatFromMongoToUser);
   }
 
+  async findByUuid(uuid: string): Promise<User | null> {
+    const user = await this.userModel.findOne({ uuid });
+
+    return user ? formatFromMongoToUser(user) : null;
+  }
+
   async findOne(where: Partial<User>): Promise<BasicUser | null> {
     const user: DatabaseUser = await this.userModel.findOne(where);
 
@@ -116,11 +122,11 @@ export class MongoDBUsersRepository implements UsersRepository {
   }
 
   addTotalUsedSpaceBytes(
-    id: string,
+    uuid: string,
     totalUsedSpaceBytes: number
   ): Promise<void> {
     return this.userModel.updateOne(
-      { _id: id },
+      { uuid },
       { $inc: { totalUsedSpaceBytes } }
     );
   }

--- a/lib/core/users/Repository.ts
+++ b/lib/core/users/Repository.ts
@@ -2,11 +2,12 @@ import { BasicUser, CreateUserData, User } from "./User";
 
 export interface UsersRepository {
   findById(id: User['id']): Promise<User | null>;
+  findByUuid(uuid: User['uuid']): Promise<User | null>;
   findOne(where: Partial<User>): Promise<BasicUser | null>;
   findByEmail(email: User['email']): Promise<User | null>;
   findByIds(ids: User['id'][]): Promise<User[]>;
   create(data: CreateUserData): Promise<BasicUser>;
-  addTotalUsedSpaceBytes(id: User['id'], totalUsedSpaceBytes: number): Promise<void>;
+  addTotalUsedSpaceBytes(uuid: User['uuid'], totalUsedSpaceBytes: number): Promise<void>;
   updateById(id: User['id'], update: Partial<User>): Promise<User | null>;
   updateByEmail(email: User['email'], update: Partial<User>): Promise<User | null>;
   updateByUuid(uuid: User['uuid'], update: Partial<User>): Promise<BasicUser | null>;

--- a/lib/core/users/Repository.ts
+++ b/lib/core/users/Repository.ts
@@ -7,7 +7,7 @@ export interface UsersRepository {
   findByEmail(email: User['email']): Promise<User | null>;
   findByIds(ids: User['id'][]): Promise<User[]>;
   create(data: CreateUserData): Promise<BasicUser>;
-  addTotalUsedSpaceBytes(uuid: User['uuid'], totalUsedSpaceBytes: number): Promise<void>;
+  addTotalUsedSpaceBytes(uuid: User['uuid'], totalUsedSpaceBytes: User['totalUsedSpaceBytes']): Promise<void>;
   updateById(id: User['id'], update: Partial<User>): Promise<User | null>;
   updateByEmail(email: User['email'], update: Partial<User>): Promise<User | null>;
   updateByUuid(uuid: User['uuid'], update: Partial<User>): Promise<BasicUser | null>;

--- a/lib/core/users/usecase.ts
+++ b/lib/core/users/usecase.ts
@@ -65,7 +65,7 @@ export class UsersUsecase {
   ) {}
 
   async findOrCreateUser(email: string, password: string): Promise<BasicUser> {
-    const user = await this.usersRepository.findById(email);
+    const user = await this.usersRepository.findByEmail(email);
 
     if (user) {
       const newHassPass = createHash('sha256').update(password).digest('hex');
@@ -219,8 +219,8 @@ export class UsersUsecase {
     }
 
     await Promise.all([
-      this.bucketsRepository.removeAll({ user: user.id }),
-      this.framesRepository.removeAll({ user: user.id })
+      this.bucketsRepository.removeAll({ userId: user.uuid }),
+      this.framesRepository.removeAll({ user: user.email })
     ]);
 
     await this.usersRepository.removeById(user.id);

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -377,7 +377,7 @@ BucketsRouter.prototype._getBucketUnregistered = function (req, res, next) {
     }
 
     if (req.user) {
-      query.user = req.user._id;
+      query.userId = req.user.uuid;
     }
 
     Bucket.findOne(query, function (err, bucket) {
@@ -475,7 +475,7 @@ BucketsRouter.prototype.ensureCreateEntryFromFrame = async function (req, res, n
       return next(new errors.NotFoundError('Bucket not found'));
     }
 
-    const isBucketOwner = bucket.user === req.user._id;
+    const isBucketOwner = bucket.userId === req.user.uuid;
 
     if (!isBucketOwner) {
       return next(new errors.ForbiddenError());
@@ -540,7 +540,7 @@ BucketsRouter.prototype.ensureCreateEntryFromFrame = async function (req, res, n
     if (err && err.response && err.response.status === 404) {
       log.error(
         'ensureCreateEntryFromFrame/user %s tried to confirm an upload of a non-existent object',
-        req.user._id
+        req.user.uuid
       );
 
       return next(new errors.UnprocessableEntityError('File can not be created, object is missing'));
@@ -548,7 +548,7 @@ BucketsRouter.prototype.ensureCreateEntryFromFrame = async function (req, res, n
 
     log.error(
       'ensureCreateEntryFromFrame/error confirming upload for user %s: %s. %s',
-      req.user._id,
+      req.user.uuid,
       err.message,
       err.stack || 'No stack trace'
     );
@@ -638,7 +638,7 @@ BucketsRouter.prototype.createEntryFromFrame = function (req, res, next) {
 /**
  * Returns the bucket by ID
  * @param {String|ObjectId} bucketId - The unique _id for the bucket
- * @param {String} [userId] - The email address for the user
+ * @param {String} [userId] - User's uuid
  * @param {BucketsRouter~_getBucketByIdCallback}
  */
 BucketsRouter.prototype._getBucketById = function (bucketId, userId, callback) {
@@ -650,7 +650,7 @@ BucketsRouter.prototype._getBucketById = function (bucketId, userId, callback) {
   }
 
   if (userId) {
-    query.user = userId;
+    query.userId = userId;
   }
 
   this.storage.models.Bucket.findOne(query, function (err, bucket) {
@@ -871,7 +871,7 @@ BucketsRouter.prototype.listMirrorsForFile = function (req, res, next) {
   }
 
   async.waterfall([
-    this._getBucketById.bind(this, req.params.id, req.user._id),
+    this._getBucketById.bind(this, req.params.id, req.user.uuid),
     _getFrameForFile.bind(this, req.params.file),
     _getHashesFromFrame,
     _getMirrorsFromHashes
@@ -1076,7 +1076,7 @@ BucketsRouter.prototype.getFile = function (req, res, next) {
   const query = { _id: req.params.id };
 
   if (req.user) {
-    query.user = req.user._id;
+    query.userId = req.user.uuid;
   } else {
     if (req.params.id !== req.token.bucket.toString()) {
       return next(new errors.NotAuthorizedError());
@@ -1093,7 +1093,7 @@ BucketsRouter.prototype.getFile = function (req, res, next) {
     }
 
     User.findOne({
-      _id: bucket.user
+      uuid: bucket.userId
     }, function (err, user) {
       if (err) {
         return next(new errors.InternalError(err.message));
@@ -1275,7 +1275,7 @@ BucketsRouter.prototype.removeFile = async function (req, res, next) {
   }
 
   try {
-    const userId = user._id;
+    const userId = user.uuid;
 
     await this.bucketEntriesUsecase.removeFileFromUser(
       bucketId,
@@ -1531,7 +1531,7 @@ BucketsRouter.prototype.startUpload = async function (req, res, next) {
       return next(new errors.InternalError(err.message));
     }
 
-    log.error('startUpload: Error for bucket %s: for user: %s %s. %s', bucketId, req.user._id, err.message, err.stack);
+    log.error('startUpload: Error for bucket %s: for user: %s %s. %s', bucketId, req.user.uuid, err.message, err.stack);
 
     return next(new errors.InternalError());
   }

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -134,7 +134,7 @@ BucketsRouter.prototype._validate = function (req, res, next) {
  * @param {Function} next
  */
 BucketsRouter.prototype.getBuckets = function (req, res, next) {
-  let findQuery = { user: req.user._id };
+  let findQuery = { userId: req.user.uuid };
   const startDate = utils.parseTimestamp(req.query.startDate);
   if (startDate) {
     findQuery.created = { $gt: startDate };
@@ -166,7 +166,7 @@ BucketsRouter.prototype.getBucketById = function (req, res, next) {
 
   Bucket.findOne({
     _id: req.params.id,
-    user: req.user._id
+    userId: req.user.uuid
   }, function (err, bucket) {
     if (err) {
       return next(new errors.InternalError(err.message));
@@ -184,7 +184,7 @@ BucketsRouter.prototype.getBucketId = function (req, res, next) {
   const Bucket = this.storage.models.Bucket;
 
   Bucket.findOne({
-    user: req.user._id,
+    userId: req.user.uuid,
     name: req.params.name
   }, '_id', { lean: true }, function (err, bucket) {
     if (err) {
@@ -261,7 +261,7 @@ BucketsRouter.prototype.destroyBucketById = function (req, res, next) {
     return next(new errors.ConflictError('This user has bucket deletion disabled'));
   }
 
-  Bucket.findOne({ _id: req.params.id, user: req.user._id }, (err, bucket) => {
+  Bucket.findOne({ _id: req.params.id, userId: req.user.uuid }, (err, bucket) => {
     if (err) {
       return next(new errors.InternalError(err.message));
     }
@@ -291,7 +291,7 @@ BucketsRouter.prototype.updateBucketById = function (req, res, next) {
 
   Bucket.findOne({
     _id: req.params.id,
-    user: req.user._id
+    userId: req.user.uuid
   }, (err, bucket) => {
     if (err) {
       return next(new errors.InternalError(err.message));
@@ -410,7 +410,7 @@ BucketsRouter.prototype.createBucketToken = function (req, res, next) {
 
   Bucket.findOne({
     _id: req.params.id,
-    user: req.user._id
+    userId: req.user.uuid
   }, function (err, bucket) {
     if (err) {
       return next(err);
@@ -481,7 +481,7 @@ BucketsRouter.prototype.ensureCreateEntryFromFrame = async function (req, res, n
       return next(new errors.ForbiddenError());
     }
 
-    const frame = await Frame.findOne({ _id: req.body.frame, user: req.user._id });
+    const frame = await Frame.findOne({ _id: req.body.frame, user: req.user.email });
 
     if (!frame) {
       return next(new errors.NotFoundError('Frame not found'));
@@ -580,7 +580,7 @@ BucketsRouter.prototype.createEntryFromFrame = function (req, res, next) {
   });
 
   Bucket.findOne({
-    user: req.user._id,
+    userId: req.user.uuid,
     _id: req.params.id
   }, function (err, bucket) {
     if (err) {
@@ -593,7 +593,7 @@ BucketsRouter.prototype.createEntryFromFrame = function (req, res, next) {
 
     Frame.findOne({
       _id: req.body.frame,
-      user: req.user._id
+      user: req.user.email
     }, function (err, frame) {
       if (err) {
         return next(new errors.InternalError(err.message));
@@ -1215,7 +1215,7 @@ BucketsRouter.prototype.listFilesInBucket = function (req, res, next) {
 
   Bucket.findOne({
     _id: req.params.id,
-    user: req.user._id
+    userId: req.user.uuid
   }, (err, bucket) => {
     if (err) {
       return next(new errors.InternalError(err.message));
@@ -1356,7 +1356,7 @@ BucketsRouter.prototype.renameFile = function (req, res, next) {
 
   Bucket.findOne({
     _id: req.params.id,
-    user: req.user._id
+    userId: req.user.uuid
   }, function (err, bucket) {
     if (err) {
       return next(new errors.InternalError(err.message));
@@ -1403,7 +1403,7 @@ BucketsRouter.prototype.getFileId = function (req, res, next) {
 
   Bucket.findOne({
     _id: req.params.id,
-    user: req.user._id
+    userId: req.user.uuid
   }, '_id', { lean: true }, function (err, bucket) {
     if (err) {
       return next(new errors.InternalError(err.message));
@@ -1457,67 +1457,11 @@ BucketsRouter.prototype.getFileInfo = function (req, res, next) {
   });
 };
 
-BucketsRouter.prototype.getStorageUsage = function (req, res) {
-  const { Bucket } = this.storage.models;
-
-  var agg = Bucket.aggregate([
-    {
-      $match: {
-        user: req.user._id
-      }
-    },
-    {
-      $lookup: {
-        from: 'bucketentries',
-        localField: '_id',
-        foreignField: 'bucket',
-        as: 'bucketentry'
-      }
-    },
-    {
-      $unwind: {
-        path: '$bucketentry'
-      }
-    },
-    {
-      $lookup: {
-        from: 'frames',
-        localField: 'bucketentry.frame',
-        foreignField: '_id',
-        as: 'frame'
-      }
-    },
-    {
-      $unwind: {
-        path: '$frame'
-      }
-    },
-    {
-      $project: {
-        _id: '$frame._id',
-        user: '$frame.user',
-        size: '$frame.size'
-      }
-    },
-    {
-      $group: {
-        _id: '$user',
-        total: { $sum: '$size' }
-      }
-    }
-  ]).cursor({ batchSize: 1000 }).exec();
-
-  agg.next().then(data => {
-    // User.updateOne({ _id: data._id }, { totalUsedSpaceBytes: data.total }, (err) => { })
-    res.status(200).send(data);
-  }).catch(() => {
-    res.status(400).send({ message: 'Error' });
-  });
-};
-
 //eslint-disable-next-line complexity
 BucketsRouter.prototype.startUpload = async function (req, res, next) {
   const bucketId = req.params.id;
+
+  console.log('hola');
 
   if (!req.body.uploads) {
     return next(new errors.BadRequestError('Missing "uploads" field'));
@@ -1549,7 +1493,7 @@ BucketsRouter.prototype.startUpload = async function (req, res, next) {
 
   try {
     const uploadsResult = await this.usecase.startUpload(
-      req.user._id,
+      req.user.uuid,
       bucketId,
       this.CLUSTER,
       uploads,
@@ -1631,7 +1575,7 @@ BucketsRouter.prototype.finishUpload = async function (req, res, next) {
 
   try {
     const bucketEntry = await this.usecase.completeUpload(
-      req.user._id,
+      req.user.uuid,
       bucketId,
       index,
       shards,
@@ -1733,7 +1677,6 @@ BucketsRouter.prototype._definitions = function () {
     ['POST', '/buckets/:id/files', this.getLimiter(limiter(1000)), this._validate, this._verify, this.createEntryFromFrame],
     ['POST', '/buckets/:id/files/ensure', this.getLimiter(limiter(1000)), this._validate, this._verify, this.ensureCreateEntryFromFrame],
     ['GET', '/buckets/:id/files/:file/mirrors', this.getLimiter(limiter(1000)), this._validate, this._verify, this.listMirrorsForFile],
-    ['GET', '/usage', this.getLimiter(limiter(1000)), this._verify, this.getStorageUsage],
     ['PATCH', '/buckets/:id/files/:file', this.getLimiter(limiter(1000)), this._validate, this._verify, this.renameFile],
     ['POST', '/v2/buckets/:id/files/start', this.getLimiter(limiter(1000)), this._validate, this._verify, this.startUpload],
     ['POST', '/v2/buckets/:id/files/finish', this.getLimiter(limiter(1000)), this._validate, this._verify, this.finishUpload],

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1461,8 +1461,6 @@ BucketsRouter.prototype.getFileInfo = function (req, res, next) {
 BucketsRouter.prototype.startUpload = async function (req, res, next) {
   const bucketId = req.params.id;
 
-  console.log('hola');
-
   if (!req.body.uploads) {
     return next(new errors.BadRequestError('Missing "uploads" field'));
   }

--- a/lib/server/routes/frames.js
+++ b/lib/server/routes/frames.js
@@ -117,10 +117,10 @@ FramesRouter.prototype.getFrameById = function (req, res, next) {
   });
 };
 
-function getStorageLimit(storage, user) {
+function getStorageLimit(storage, userId) {
   return new Promise((resolve, reject) => {
 
-    storage.models.User.findOne({ _id: user }, function (err, _user) {
+    storage.models.User.findOne({ uuid: userId }, function (err, _user) {
       if (err) {
         reject({ error: 'Internal error', statusCode: 500 });
       }
@@ -140,7 +140,7 @@ function getStorageLimit(storage, user) {
 }
 
 FramesRouter.prototype.getStorageLimit = function (req, res) {
-  getStorageLimit(this.storage, req.user._id).then(result => {
+  getStorageLimit(this.storage, req.user.uuid).then(result => {
     res.status(result.statusCode).send({ maxSpaceBytes: result.maxSpaceBytes });
   }).catch(err => {
     res.status(err.statusCode).send({ error: err.error });

--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -456,7 +456,7 @@ UsersRouter.prototype.confirmDestroyUser = function (req, res, next) {
 
     Bucket.remove(
       {
-        user: user.email,
+        userId: user.uuid,
       },
       (err) => {
         if (err) {


### PR DESCRIPTION
**_These changes break the dependency of the email for the V2 API._** 

From now in advance, the `email` will be used only for the V1 API. The migration to handle the _buckets_ collection that was using the field `user` (which is the user's `email`) has been migrated. From now in advance, the `userId` will be the reference field to relate _users_ with _buckets_ as this field uses a constant value, which is the user's UUID. 

There is still a missing part to allow updating the email: stop using it as the ID on the user's collection.