### PR TITLE
[PB-2515]: fix/shard usecase networkqueue

### DIFF
--- a/bin/cli/init.ts
+++ b/bin/cli/init.ts
@@ -97,6 +97,7 @@ export async function prepare(): Promise<PrepareFunctionReturnType> {
 
   const shardsUsecase = new ShardsUsecase(
     mirrorsRepository,
+    contactsRepository,
     networkQueue
   );
   const bucketEntriesUsecase = new BucketEntriesUsecase(

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -81,6 +81,7 @@ function BucketsRouter(options) {
 
   this.shardsUseCase = new ShardsUsecase(
     mirrorsRepository,
+    contactsRepository,
     this.networkQueue,
   );
 


### PR DESCRIPTION
After contactsRepository was added as a paramter to shardUseCase constructor, two references were not updated. This caused errors in bucket controller, specifically in `removeFile` where this.networkQueue was undefined.