### PR TITLE
[_] chore: add logger to finishUpload endpoint

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1210,6 +1210,7 @@ BucketsRouter.prototype.startUpload = async function (req, res, next) {
 // eslint-disable-next-line complexity
 BucketsRouter.prototype.finishUpload = async function (req, res, next) {
   const bucketId = req.params.id;
+  const driveClient = req.headers['internxt-client'];
 
   if (!req.body.index || !req.body.shards) {
     return next(new errors.BadRequestError('Missing parameters'));
@@ -1270,6 +1271,16 @@ BucketsRouter.prototype.finishUpload = async function (req, res, next) {
       return next(new errors.TransferRateError(err.message));
     }
 
+    const errorDetails = {
+      client: driveClient,
+      body: req.body,
+      headers: req.headers,
+      errorMessage: err.message,
+      errorStack: err.stack,
+    };
+
+    log.error('finishUpload: Error for bucket %s: for user: %s, details: %s', bucketId, req.user.uuid, JSON.stringify(errorDetails));
+    
     return next(new errors.InternalError(err.message));
   }
 };


### PR DESCRIPTION
This PR introduces a log that includes the `internxt-client` header to identify the platform responsible for a specific error.

![image](https://github.com/user-attachments/assets/f7272794-dea6-4fa7-8194-91d449ebb7e0)
