### PR TITLE
[_] refactor(buckets): remove callbacks from buckets routes

### DIFF
--- a/lib/core/buckets/MongoDBBucketsRepository.ts
+++ b/lib/core/buckets/MongoDBBucketsRepository.ts
@@ -1,6 +1,7 @@
 import { Model } from 'mongoose';
 import { Bucket } from './Bucket';
 import { BucketsRepository } from './Repository';
+import constants from '../../constants';
 
 export const formatFromMongoToBucket = (mongoBucket: any): Bucket => {
   const id = mongoBucket._id.toString();
@@ -71,5 +72,20 @@ export class MongoDBBucketsRepository implements BucketsRepository {
 
   async removeAll(where: Partial<Bucket>): Promise<void> {
     await this.model.deleteMany(where);
+  }
+
+  async findUserBucketsFromDate(userId: Bucket['id'], date?: Date, limit?: number): Promise<Bucket[]> {
+    const maxBuckets = limit ?? constants.DEFAULT_MAX_BUCKETS;
+    const findQuery = {
+      userId,
+      ...(date ? { created: { $gt: date } } : {})
+    };
+
+    const buckets = await this.model
+      .find(findQuery)
+      .sort({ created: 1 })
+      .limit(maxBuckets)
+
+    return buckets.map(formatFromMongoToBucket)
   }
 }

--- a/lib/core/buckets/MongoDBBucketsRepository.ts
+++ b/lib/core/buckets/MongoDBBucketsRepository.ts
@@ -1,3 +1,4 @@
+import { Model } from 'mongoose';
 import { Bucket } from './Bucket';
 import { BucketsRepository } from './Repository';
 
@@ -12,6 +13,13 @@ export const formatFromMongoToBucket = (mongoBucket: any): Bucket => {
 };
 export class MongoDBBucketsRepository implements BucketsRepository {
   constructor(private model: any) {}
+
+  async create(newBucketData: Omit<Bucket, 'id'>): Promise<Bucket> {
+    const bucket = new this.model(newBucketData);
+    const bucketCreated = await bucket.save();
+
+    return formatFromMongoToBucket(bucketCreated);
+  }
 
   async find(where: Partial<Bucket>): Promise<Bucket[]> {
     const query = where.id ? { ...where, _id: where.id } : where;
@@ -48,8 +56,8 @@ export class MongoDBBucketsRepository implements BucketsRepository {
     return formatFromMongoToBucket(rawModel);
   }
 
-  destroyByUser(userId: Bucket['userId']): Promise<void> {
-    return this.model.deleteMany({
+  async destroyByUser(userId: Bucket['userId']): Promise<void> {
+    await this.model.deleteMany({
       userId,
     });
   }
@@ -61,7 +69,7 @@ export class MongoDBBucketsRepository implements BucketsRepository {
     });
   }
 
-  removeAll(where: Partial<Bucket>): Promise<void> {
-    return this.model.deleteMany(where);
+  async removeAll(where: Partial<Bucket>): Promise<void> {
+    await this.model.deleteMany(where);
   }
 }

--- a/lib/core/buckets/Repository.ts
+++ b/lib/core/buckets/Repository.ts
@@ -1,6 +1,7 @@
 import { Bucket } from './Bucket';
 
 export interface BucketsRepository {
+  create(bucket: Omit<Bucket, 'id'>): Promise<Bucket>;
   findOne(where: Partial<Bucket>): Promise<Bucket | null>;
   findByUser(userId: Bucket['userId'], limit: number, skip: number): Promise<Bucket[]>;
   findByIds(ids: Bucket['id'][]): Promise<Bucket[]>;

--- a/lib/core/buckets/Repository.ts
+++ b/lib/core/buckets/Repository.ts
@@ -6,6 +6,7 @@ export interface BucketsRepository {
   findByUser(userId: Bucket['userId'], limit: number, skip: number): Promise<Bucket[]>;
   findByIds(ids: Bucket['id'][]): Promise<Bucket[]>;
   find(where: Partial<Bucket>): Promise<Bucket[]>;
+  findUserBucketsFromDate(userId: Bucket['id'], date?: Date, limit?: number): Promise<Bucket[]>;
   destroyByUser(userId: Bucket['userId']): Promise<void>;
   removeAll(where: Partial<Bucket>): Promise<void>;
   removeByIdAndUser(bucketId: Bucket['id'], userId:  Bucket['userId']): Promise<void> 

--- a/lib/core/buckets/usecase.ts
+++ b/lib/core/buckets/usecase.ts
@@ -127,7 +127,7 @@ export class BucketNameAlreadyInUse extends Error {
   constructor() {
     super('Name already used by another bucket');
 
-    Object.setPrototypeOf(this, EmptyMirrorsError.prototype);
+    Object.setPrototypeOf(this, BucketNameAlreadyInUse.prototype);
   }
 }
 

--- a/lib/core/buckets/usecase.ts
+++ b/lib/core/buckets/usecase.ts
@@ -319,6 +319,13 @@ export class BucketsUsecase {
     return bucket;
   }
 
+  async findAllByUserAndCreatedSince(userId: Bucket['userId'], createdSince?: Date): Promise<Bucket[]> {
+    const buckets = await this.bucketsRepository.findUserBucketsFromDate(userId, createdSince);
+
+    return buckets;
+  }
+
+
   async getUserUsage(user: Frame['user']): Promise<number> {
     const usage = await this.framesRepository.getUserUsage(user);
 

--- a/lib/core/buckets/usecase.ts
+++ b/lib/core/buckets/usecase.ts
@@ -11,7 +11,7 @@ import {
 } from '../shards/Shard';
 import { BucketEntry } from '../bucketEntries/BucketEntry';
 import { BucketEntryShard } from '../bucketEntryShards/BucketEntryShard';
-
+import crypto from 'crypto';
 import { BucketEntriesRepository } from '../bucketEntries/Repository';
 import { BucketEntryShardsRepository } from '../bucketEntryShards/Repository';
 import { FramesRepository } from '../frames/Repository';
@@ -118,6 +118,14 @@ export class NoNodeFoundError extends Error {
 export class EmptyMirrorsError extends Error {
   constructor() {
     super('Empty mirrors');
+
+    Object.setPrototypeOf(this, EmptyMirrorsError.prototype);
+  }
+}
+
+export class BucketNameAlreadyInUse extends Error {
+  constructor() {
+    super('Name already used by another bucket');
 
     Object.setPrototypeOf(this, EmptyMirrorsError.prototype);
   }
@@ -708,5 +716,27 @@ export class BucketsUsecase {
 
   async destroyByUser(userId: User['uuid']) {
     await this.bucketsRepository.destroyByUser(userId);
+  }
+
+  async create(user: User, newBucket: Bucket) {
+    const payload = {
+      ...newBucket,
+      status: 'Active',
+      pubkeys: newBucket.pubkeys,
+      user: user.id,
+      userId: user.uuid,
+    };
+
+    if (!payload.name) {
+      payload['name'] = "Bucket-" + crypto.randomBytes(3).toString("hex");
+    }
+
+    const existentBucket = await this.bucketsRepository.findOne({ userId: user.uuid, name: payload.name });
+
+    if (existentBucket) {
+      throw new BucketNameAlreadyInUse();
+    }
+
+    return this.bucketsRepository.create(payload);
   }
 }

--- a/lib/core/buckets/usecase.ts
+++ b/lib/core/buckets/usecase.ts
@@ -305,6 +305,12 @@ export class BucketsUsecase {
     return bucket;
   }
 
+  async findByIdAndUser(id: Bucket['id'], userId: Bucket['userId']): Promise<Bucket | null> {
+    const bucket = await this.bucketsRepository.findOne({ id, userId });
+
+    return bucket;
+  }
+
   async getUserUsage(user: Frame['user']): Promise<number> {
     const usage = await this.framesRepository.getUserUsage(user);
 

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -134,26 +134,14 @@ BucketsRouter.prototype._validate = function (req, res, next) {
  * @param {http.ServerResponse} res
  * @param {Function} next
  */
-BucketsRouter.prototype.getBuckets = function (req, res, next) {
-  let findQuery = { userId: req.user.uuid };
+BucketsRouter.prototype.getBuckets = async function (req, res, next) {
+  const userId = req.user.uuid;
   const startDate = utils.parseTimestamp(req.query.startDate);
-  if (startDate) {
-    findQuery.created = { $gt: startDate };
-  }
 
-  this.storage.models.Bucket
-    .find(findQuery)
-    .sort({ created: 1 })
-    .limit(constants.DEFAULT_MAX_BUCKETS)
-    .exec(function (err, buckets) {
-      if (err) {
-        return next(new errors.InternalError(err.message));
-      }
+  const buckets = await this.usecase.findAllByUserAndCreatedSince(userId, startDate)
+    .catch(err=> next(new errors.InternalError(err.message)));
 
-      res.status(200).send(buckets.map(function (bucket) {
-        return bucket.toObject();
-      }));
-    });
+  res.status(200).send(buckets);
 };
 
 /**

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -22,7 +22,7 @@ const { v4: uuidv4, validate: uuidValidate } = require('uuid');
 const { isHexString } = require('../middleware/farmer-auth');
 const axios = require('axios');
 const { MongoDBBucketEntriesRepository } = require('../../core/bucketEntries/MongoDBBucketEntriesRepository');
-const { BucketsUsecase, BucketEntryNotFoundError, BucketEntryFrameNotFoundError, BucketNotFoundError, BucketForbiddenError, MissingUploadsError, MaxSpaceUsedError, InvalidUploadIndexes, InvalidMultiPartValueError, NoNodeFoundError, EmptyMirrorsError } = require('../../core/buckets/usecase');
+const { BucketsUsecase, BucketEntryNotFoundError, BucketEntryFrameNotFoundError, BucketNotFoundError, BucketForbiddenError, MissingUploadsError, MaxSpaceUsedError, InvalidUploadIndexes, InvalidMultiPartValueError, NoNodeFoundError, EmptyMirrorsError, BucketNameAlreadyInUse } = require('../../core/buckets/usecase');
 const { BucketEntriesUsecase, BucketEntryVersionNotFoundError } = require('../../core/bucketEntries/usecase');
 const { MongoDBBucketEntryShardsRepository } = require('../../core/bucketEntryShards/MongoDBBucketEntryShardsRepository');
 const { MongoDBMirrorsRepository } = require('../../core/mirrors/MongoDBMirrorsRepository');
@@ -187,37 +187,43 @@ BucketsRouter.prototype.getBucketById = function (req, res, next) {
  * @param {http.ServerResponse} res
  * @param {Function} next
  */
-BucketsRouter.prototype.createBucket = function (req, res, next) {
-  const Bucket = this.storage.models.Bucket;
+BucketsRouter.prototype.createBucket = async function (req, res, next) {
+  const { body, user, pubkey } = req;
   const PublicKey = this.storage.models.PublicKey;
 
-  if (req.body.name && req.body.name.length > constants.MAX_BUCKETNAME) {
+  if (body.name && body.name.length > constants.MAX_BUCKETNAME) {
     return next(new errors.BadRequestError('Maximum bucket name'));
   }
 
-  if (!Array.isArray(req.body.pubkeys)) {
-    req.body.pubkeys = [];
+  const pubkeys = Array.isArray(body.pubkeys) ? body.pubkeys : [];
+  if (pubkey && !pubkeys.includes(pubkey._id)) {
+    pubkeys.push(pubkey._id);
   }
 
-  if (req.pubkey && req.body.pubkeys.indexOf(req.pubkey._id) === -1) {
-    req.body.pubkeys.push(req.pubkey._id);
-  }
+  const allPubkeysValid = pubkeys.every(key => {
+    try {
+      PublicKey.validate(key);
 
-  try {
-    for (let k = 0; k < req.body.pubkeys.length; k++) {
-      PublicKey.validate(req.body.pubkeys[k]);
+      return true;
+    } catch {
+      return false;
     }
-  } catch (err) {
+  });
+
+  if (!allPubkeysValid) {
     return next(new errors.BadRequestError('Invalid public key supplied'));
   }
 
-  Bucket.create(req.user, req.body, function (err, bucket) {
-    if (err) {
-      return next(err);
-    }
+  try {
+    const createdBucket = await this.usecase.create(user, body);
+    res.status(201).send(createdBucket);
+  } catch (err) {
+    const errorType = err instanceof BucketNameAlreadyInUse
+      ? errors.ConflictError
+      : errors.InternalError;
 
-    res.status(201).send(bucket.toObject());
-  });
+    return next(new errorType(err.message));
+  }
 };
 
 /**

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -292,52 +292,55 @@ BucketsRouter.prototype.updateBucketById = async function (req, res, next) {
  * @param {http.ServerResponse} res
  * @param {Function} next
  */
-BucketsRouter.prototype.createBucketToken = function (req, res, next) {
+BucketsRouter.prototype.createBucketToken = async function (req, res, next) {
   const { Token, BucketEntry, Bucket } = this.storage.models;
 
-  Bucket.findOne({
-    _id: req.params.id,
-    userId: req.user.uuid
-  }, function (err, bucket) {
-    if (err) {
-      return next(err);
-    }
+  try {
+    const bucket = await Bucket.findOne({
+      _id: req.params.id,
+      userId: req.user.uuid
+    });
 
     if (!bucket) {
       return next(new errors.NotFoundError('Bucket not found'));
     }
 
-    Token.create(bucket, req.body.operation, function (err, token) {
-      if (err) {
-        return next(new errors.InternalError(err.message));
-      }
-
-      const tokenObject = token.toObject();
-      tokenObject.encryptionKey = bucket.encryptionKey;
-
-      const file = req.body.file;
-      if (!file || req.body.operation !== 'PULL') {
-        res.status(201).send(tokenObject);
-
-        return;
-      }
-
-      BucketEntry.findOne({
-        _id: file,
-        bucket: bucket._id
-      }).populate('frame').exec(function (err, bucketEntry) {
+    const token = await new Promise((resolve, reject) => {
+      Token.create(bucket, req.body.operation, (err, token) => {
         if (err) {
-          return next(err);
+          reject(err);
+        } else {
+          resolve(token);
         }
-        if (!bucketEntry) {
-          return next(new errors.NotFoundError('Bucket entry not found'));
-        }
-        tokenObject.mimetype = bucketEntry.mimetype;
-        tokenObject.size = (bucketEntry.frame && bucketEntry.frame.size) || bucketEntry.size;
-        res.status(201).send(tokenObject);
       });
     });
-  });
+
+    const tokenObject = token.toObject();
+    tokenObject.encryptionKey = bucket.encryptionKey;
+
+    const file = req.body.file;
+    if (!file || req.body.operation !== 'PULL') {
+      res.status(201).send(tokenObject);
+
+      return;
+    }
+
+    const bucketEntry = await BucketEntry.findOne({
+      _id: file,
+      bucket: bucket._id
+    }).populate('frame').exec();
+
+    if (!bucketEntry) {
+      return next(new errors.NotFoundError('Bucket entry not found'));
+    }
+
+    tokenObject.mimetype = bucketEntry.mimetype;
+    tokenObject.size = (bucketEntry.frame && bucketEntry.frame.size) || bucketEntry.size;
+    res.status(201).send(tokenObject);
+
+  } catch (err) {
+    return next(new errors.InternalError(err.message));
+  }
 };
 
 /**

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -298,78 +298,6 @@ BucketsRouter.prototype.updateBucketById = function (req, res, next) {
 };
 
 /**
- * Loads the bucket for an authorized but unregistered user
- * @private
- * @param {http.IncomingMessage} req
- * @param {http.ServerResponse} res
- * @param {Function} next
- */
-BucketsRouter.prototype._getBucketUnregistered = function (req, res, next) {
-  const self = this;
-  const Bucket = this.storage.models.Bucket;
-
-  let query = { _id: req.params.id };
-  let strategy = authenticate._detectStrategy(req);
-  let rawBody = self._verify[0];
-  let checkAuth = self._verify[1];
-  let isPublicBucket = self._isPublic;
-
-  if (req.token) {
-    if (req.token.bucket.toString() !== req.params.id) {
-      return next(new errors.NotAuthorizedError());
-    }
-
-    query = { _id: req.params.id };
-  }
-
-  function _checkAuthIfNotPublic(req, res, next) {
-    isPublicBucket(req, res, function (err) {
-      if (err) {
-        return checkAuth(req, res, next);
-      }
-
-      next(null);
-    });
-  }
-
-  async.series([
-    rawBody.bind(null, req, res),
-    _checkAuthIfNotPublic.bind(null, req, res)
-  ], (err) => {
-    if (err) {
-      if (strategy === 'ECDSA' && authenticate._verifySignature(req)) {
-        query.pubkeys = { $in: [req.header('x-pubkey')] };
-      }
-
-      if (!req.token) {
-        return next(err);
-      }
-    }
-
-    if (req.user) {
-      query.userId = req.user.uuid;
-    }
-
-    Bucket.findOne(query, function (err, bucket) {
-      if (err) {
-        return next(new errors.InternalError(err.message));
-      }
-
-      if (!bucket) {
-        return next(new errors.NotFoundError('Bucket not found'));
-      }
-
-      next(null, bucket);
-    });
-  });
-};
-/**
- * @callback BucketsRouter~_getBucketUnregisteredCallback
- * @param {Error|null} [error]
- * @param {Bucket} bucket
- */
-
-/**
  * Creates a bucket operation token
  * @param {http.IncomingMessage} req
  * @param {http.ServerResponse} res
@@ -1092,10 +1020,13 @@ BucketsRouter.prototype.deletePointers = async function (pointers) {
   }
 };
 
-BucketsRouter.prototype.getFileInfo = function (req, res, next) {
-  this._getBucketUnregistered(req, res, (err, bucket) => {
-    if (err) {
-      return next(err);
+// eslint-disable-next-line complexity
+BucketsRouter.prototype.getFileInfo = async function (req, res, next) {
+  try {
+    const bucket = await this.usecase.findByIdAndUser(req.params.id, req.user.uuid);
+
+    if (!bucket) {
+      throw new BucketNotFoundError();
     }
 
     let partSize = req.query.partSize;
@@ -1108,31 +1039,30 @@ BucketsRouter.prototype.getFileInfo = function (req, res, next) {
       }
     }
 
-    this.usecase.getFileInfo(bucket._id, req.params.file, partSize).then((fileInfo) => {
-      if ('shards' in fileInfo) {
-        const fileShards = fileInfo.shards.map((s) => {
-          return formatShardHash(s);
-        });
-        fileInfo.shards = fileShards;
-      }
+    const fileInfo = await this.usecase.getFileInfo(bucket.id, req.params.file, partSize);
+    if ('shards' in fileInfo) {
+      const fileShards = fileInfo.shards.map((s) => {
+        return formatShardHash(s);
+      });
+      fileInfo.shards = fileShards;
+    }
 
-      return res.status(200).send(fileInfo);
-    }).catch((err) => {
-      if (err instanceof BucketEntryNotFoundError || err instanceof BucketEntryFrameNotFoundError) {
-        return next(new errors.NotFoundError(err.message));
-      }
+    return res.status(200).send(fileInfo);
+  } catch (err) {
+    if (err instanceof BucketEntryNotFoundError || err instanceof BucketEntryFrameNotFoundError || err instanceof BucketNotFoundError) {
+      return next(new errors.NotFoundError(err.message));
+    }
 
-      if (err instanceof EmptyMirrorsError) {
-        log.error('getFileInfo: Missing mirrors for file %s: %s. %s', req.params.file, err.message, err.stack);
-
-        return next(new errors.InternalError(err.message));
-      }
-
-      log.error('getFileInfo: Error for file %s: %s. %s', req.params.file, err.message, err.stack);
+    if (err instanceof EmptyMirrorsError) {
+      log.error('getFileInfo: Missing mirrors for file %s: %s. %s', req.params.file, err.message, err.stack);
 
       return next(new errors.InternalError(err.message));
-    });
-  });
+    }
+
+    log.error('getFileInfo: Error for file %s: %s. %s', req.params.file, err.message, err.stack);
+
+    return next(new errors.InternalError(err.message));
+  }
 };
 
 //eslint-disable-next-line complexity
@@ -1286,7 +1216,7 @@ BucketsRouter.prototype.finishUpload = async function (req, res, next) {
     };
 
     log.error('finishUpload: Error for bucket %s: for user: %s, details: %s', bucketId, req.user.uuid, JSON.stringify(errorDetails));
-    
+
     return next(new errors.InternalError(err.message));
   }
 };

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -249,24 +249,21 @@ BucketsRouter.prototype.destroyBucketById = async function (req, res, next) {
  * @param {http.ServerResponse} res
  * @param {Function} next
  */
-BucketsRouter.prototype.updateBucketById = function (req, res, next) {
+BucketsRouter.prototype.updateBucketById = async function (req, res, next) {
   const PublicKey = this.storage.models.PublicKey;
   const Bucket = this.storage.models.Bucket;
 
-  Bucket.findOne({
-    _id: req.params.id,
-    userId: req.user.uuid
-  }, (err, bucket) => {
-    if (err) {
-      return next(new errors.InternalError(err.message));
-    }
+  try {
+    const bucket = await Bucket.findOne({
+      _id: req.params.id,
+      userId: req.user.uuid
+    });
 
     if (!bucket) {
       return next(new errors.NotFoundError('Bucket not found'));
     }
 
     const allowed = ['pubkeys', 'encryptionKey', 'publicPermissions'];
-
     for (let prop in req.body) {
       if (allowed.indexOf(prop) !== -1) {
         bucket[prop] = req.body[prop];
@@ -281,14 +278,12 @@ BucketsRouter.prototype.updateBucketById = function (req, res, next) {
       return next(new errors.BadRequestError('Invalid public key supplied'));
     }
 
-    bucket.save((err) => {
-      if (err) {
-        return next(new errors.InternalError(err.message));
-      }
+    const bucketUpdated = await bucket.save();
 
-      res.status(200).send(bucket.toObject());
-    });
-  });
+    return res.status(200).send(bucketUpdated.toObject());
+  } catch (error) {
+    return next(new errors.InternalError(error.message));
+  }
 };
 
 /**
@@ -354,6 +349,7 @@ BucketsRouter.prototype.createBucketToken = function (req, res, next) {
 BucketsRouter.prototype._getBucketById = function (bucketId, userId, callback) {
   const query = { _id: bucketId };
 
+  // In case userId was not sent
   if (typeof userId === 'function') {
     callback = userId;
     userId = null;

--- a/tests/lib/core/buckets/usecase.test.ts
+++ b/tests/lib/core/buckets/usecase.test.ts
@@ -10,7 +10,7 @@ import { UsersRepository } from '../../../../lib/core/users/Repository';
 
 import { MongoDBBucketsRepository } from '../../../../lib/core/buckets/MongoDBBucketsRepository';
 import { MongoDBBucketEntriesRepository } from '../../../../lib/core/bucketEntries/MongoDBBucketEntriesRepository';
-import { BucketNotFoundError, BucketsUsecase } from '../../../../lib/core/buckets/usecase';
+import { BucketNotFoundError, BucketNameAlreadyInUse, BucketsUsecase } from '../../../../lib/core/buckets/usecase';
 import { MongoDBFramesRepository } from '../../../../lib/core/frames/MongoDBFramesRepository';
 import { MongoDBMirrorsRepository } from '../../../../lib/core/mirrors/MongoDBMirrorsRepository';
 import { MongoDBShardsRepository } from '../../../../lib/core/shards/MongoDBShardsRepository';
@@ -277,6 +277,70 @@ describe('BucketEntriesUsecase', function () {
       await bucketsUsecase.deleteBucketByIdAndUser(bucket.id, user.uuid)
 
       expect(bucketsRepository.removeByIdAndUser).toHaveBeenCalledWith(bucket.id, user.uuid)
+    });
+  });
+
+  describe('create()', () => {
+    const user = fixtures.getUser();
+    
+    it('Should throw if bucket name already exists for user', async () => {
+      const newBucket = fixtures.getBucket({ name: 'existing-bucket' });
+      const existingBucket = fixtures.getBucket({ userId: user.uuid, name: 'existing-bucket' });
+      
+      stub(bucketsRepository, 'findOne').resolves(existingBucket);
+
+      await expect(bucketsUsecase.create(user, newBucket)).rejects.toThrow(BucketNameAlreadyInUse);
+    });
+
+    it('Should create bucket with default name if no name provided', async () => {
+      const newBucket = fixtures.getBucket({ name: undefined });
+      const expectedBucket = fixtures.getBucket({ userId: user.uuid });
+      
+      stub(bucketsRepository, 'findOne').resolves(null);
+      const createStub = stub(bucketsRepository, 'create').resolves(expectedBucket);
+
+      const result = await bucketsUsecase.create(user, newBucket);
+
+      expect(createStub.calledOnce).toBeTruthy();
+      const createArgs = createStub.firstCall.args[0];
+      expect(createArgs.status).toBe('Active');
+      expect(createArgs.user).toBe(user.id);
+      expect(createArgs.userId).toBe(user.uuid);
+      expect(createArgs.name).toMatch(/^Bucket-[a-f0-9]{6}$/);
+      expect(result).toStrictEqual(expectedBucket);
+    });
+
+    it('Should create bucket with provided name', async () => {
+      const bucketName = 'my-custom-bucket';
+      const newBucket = fixtures.getBucket({ name: bucketName });
+      const expectedBucket = fixtures.getBucket({ userId: user.uuid, name: bucketName });
+      
+      stub(bucketsRepository, 'findOne').resolves(null);
+      const createStub = stub(bucketsRepository, 'create').resolves(expectedBucket);
+
+      const result = await bucketsUsecase.create(user, newBucket);
+
+      expect(createStub.calledOnce).toBeTruthy();
+      const createArgs = createStub.firstCall.args[0];
+      expect(createArgs.status).toBe('Active');
+      expect(createArgs.user).toBe(user.id);
+      expect(createArgs.userId).toBe(user.uuid);
+      expect(createArgs.name).toBe(bucketName);
+      expect(createArgs.pubkeys).toBe(newBucket.pubkeys);
+      expect(result).toStrictEqual(expectedBucket);
+    });
+
+    it('Should check for existing bucket with same name for the user', async () => {
+      const bucketName = 'test-bucket';
+      const newBucket = fixtures.getBucket({ name: bucketName });
+      
+      const findOneStub = stub(bucketsRepository, 'findOne').resolves(null);
+      stub(bucketsRepository, 'create').resolves(fixtures.getBucket());
+
+      await bucketsUsecase.create(user, newBucket);
+
+      expect(findOneStub.calledOnce).toBeTruthy();
+      expect(findOneStub.firstCall.args).toStrictEqual([{ userId: user.uuid, name: bucketName }]);
     });
   });
 });


### PR DESCRIPTION
## Changes

Removed callback use from queries in endpoints:
1. GET /buckets
2. POST /buckets
3. PATCH /buckets/:id
4. POST /buckets/:id/tokens
5. GET /buckets/:id/files/:file/info (some parts were still using callbacks)
