### PR TITLE
[_] refactor/remove callback from contacts routes

### DIFF
--- a/lib/server/routes/contacts.js
+++ b/lib/server/routes/contacts.js
@@ -153,7 +153,7 @@ ContactsRouter.prototype.setDefaultResponseTime = async function (nodeID) {
 
 ContactsRouter.prototype.setDefaultReputation = async function (nodeID) {
   try {
-    this.storage.models.Contact.findOneAndUpdate({
+    await this.storage.models.Contact.findOneAndUpdate({
       _id: nodeID,
       reputation: { $exists: false }
     },
@@ -264,7 +264,7 @@ ContactsRouter.prototype.getContactList = async function (req, res, next) {
   try {
     const contacts = await Contact.find(query).skip(skip).limit(limit).sort({
       lastSeen: -1
-    });
+    }).exec();
 
     const response = contacts.sort((c1, c2) => c2.lastSeen - c1.lastSeen)
       .map((c) => c.toObject());

--- a/lib/server/routes/contacts.js
+++ b/lib/server/routes/contacts.js
@@ -60,14 +60,17 @@ ContactsRouter.prototype.createChallenge = function (req, res, next) {
   });
 };
 
-ContactsRouter.prototype.getShards = function (req, res, next) {
+ContactsRouter.prototype.getShards = async function (req, res, next) {
   const shards = req.body.shards;
-  this.storage.models.Shard.find({ hash: { $in: shards } }).select('hash').exec(function (err, dataHash) {
-    if (err) {
-      return next(new errors.InternalError(err.message));
-    }
-    res.status(200).send(dataHash.map(x => x.hash));
-  });
+  try {
+    const dataHash = await this.storage.models.Shard.find({ hash: { $in: shards } }).select('hash').exec();
+
+    return res.status(200).send(dataHash.map(x => x.hash));
+  } catch (err) {
+    log.error('[CONTACTS/GET_HASHES]: Error while getting shards hashes: %s, %s', err.message, err.stack);
+
+    return next(new errors.InternalError(err.message));
+  }
 };
 
 ContactsRouter.prototype.createContact = async function (req, res, next) {
@@ -84,6 +87,7 @@ ContactsRouter.prototype.createContact = async function (req, res, next) {
     // return res.status(400).send({ message: 'Farmer with same address/port already exists' });
   }
 
+  //  Callback used as record is a custom static method defined on the model.
   Contact.record({
     nodeID: req.headers['x-node-id'],
     address: req.body.address,
@@ -127,42 +131,47 @@ ContactsRouter.prototype._getContactIP = function (addr) {
   }
 };
 
-ContactsRouter.prototype.setDefaultResponseTime = function (nodeID) {
-  this.storage.models.Contact.findOneAndUpdate({
-    _id: nodeID,
-    responseTime: { $exists: false }
-  }, {
-    $set: {
-      responseTime: 10000
-    }
-  }, {
-    upsert: false
-  }, (err) => {
-    if (err) {
-      log.error('Error setting default responseTime for %s, reason: %s',
-        nodeID, err.message);
-    }
-  });
+ContactsRouter.prototype.setDefaultResponseTime = async function (nodeID) {
+  try {
+    await this.storage.models.Contact.findOneAndUpdate({
+      _id: nodeID,
+      responseTime: { $exists: false }
+    },
+    {
+      $set: {
+        responseTime: 10000
+      }
+    },
+    {
+      upsert: false
+    });
+  } catch (err) {
+    log.error('Error setting default responseTime for %s, reason: %s',
+      nodeID, err.message);
+  }
 };
 
-ContactsRouter.prototype.setDefaultReputation = function (nodeID) {
-  this.storage.models.Contact.findOneAndUpdate({
-    _id: nodeID,
-    reputation: { $exists: false }
-  }, {
-    $set: {
-      reputation: 0
-    }
-  }, {
-    upsert: false
-  }, (err) => {
-    if (err) {
-      log.error('Error setting default reputation for %s, reason: %s',
-        nodeID, err.message);
-    }
-  });
+ContactsRouter.prototype.setDefaultReputation = async function (nodeID) {
+  try {
+    this.storage.models.Contact.findOneAndUpdate({
+      _id: nodeID,
+      reputation: { $exists: false }
+    },
+    {
+      $set: {
+        reputation: 0
+      }
+    },
+    {
+      upsert: false
+    });
+  } catch (err) {
+    log.error('Error setting default reputation for %s, reason: %s',
+      nodeID, err.message);
+  }
 };
 
+// eslint-disable-next-line complexity
 ContactsRouter.prototype.patchContactByNodeID = async function (req, res, next) {
   const { Contact } = this.storage.models;
   const nodeID = req.headers['x-node-id'];
@@ -202,13 +211,12 @@ ContactsRouter.prototype.patchContactByNodeID = async function (req, res, next) 
     data.spaceAvailable = req.body.spaceAvailable;
   }
 
-  Contact.findOneAndUpdate({ _id: nodeID }, { $set: data }, {
-    upsert: false,
-    returnNewDocument: true
-  }, (err, contact) => {
-    if (err) {
-      return next(new errors.InternalError(err.message));
-    }
+  try {
+    const contact = await Contact.findOneAndUpdate({ _id: nodeID }, { $set: data }, {
+      upsert: false,
+      returnNewDocument: true
+    });
+
     if (!contact) {
       return next(new errors.NotFoundError('Contact not found'));
     }
@@ -219,13 +227,17 @@ ContactsRouter.prototype.patchContactByNodeID = async function (req, res, next) 
       this.setDefaultReputation(nodeID);
     }
 
-    res.status(201).send({
+    return res.status(201).send({
       nodeID: contact.nodeID,
       address: contact.address,
       port: contact.port,
       spaceAvailable: contact.spaceAvailable
     });
-  });
+  } catch (err) {
+    log.error('[CONTACTS/UPDATE_CONTACT]: Error while updating contact: %s, %s', err.message, err.stack);
+
+    return next(new errors.InternalError(err.message));
+  }
 };
 
 /**
@@ -234,7 +246,7 @@ ContactsRouter.prototype.patchContactByNodeID = async function (req, res, next) 
  * @param {http.ServerResponse} res
  * @param {Function} next
  */
-ContactsRouter.prototype.getContactList = function (req, res, next) {
+ContactsRouter.prototype.getContactList = async function (req, res, next) {
   const Contact = this.storage.models.Contact;
 
   let allowedQueryParams = ['address'];
@@ -249,21 +261,20 @@ ContactsRouter.prototype.getContactList = function (req, res, next) {
     }
   }
 
-  let cursor = Contact.find(query).skip(skip).limit(limit).sort({
-    lastSeen: -1
-  });
+  try {
+    const contacts = await Contact.find(query).skip(skip).limit(limit).sort({
+      lastSeen: -1
+    });
 
-  cursor.exec(function (err, contacts) {
-    if (err) {
-      return next(new errors.InternalError(err.message));
-    }
+    const response = contacts.sort((c1, c2) => c2.lastSeen - c1.lastSeen)
+      .map((c) => c.toObject());
 
-    res.status(200).send(contacts.sort(function (c1, c2) {
-      return c2.lastSeen - c1.lastSeen;
-    }).map(function (c) {
-      return c.toObject();
-    }));
-  });
+    return res.status(200).send(response);
+  } catch (err) {
+    log.error('[CONTACTS/GET_CONTACTS]: Error while getting contacts: %s, %s', err.message, err.stack);
+
+    return next(new errors.InternalError(err.message));
+  }
 };
 
 /**
@@ -272,13 +283,11 @@ ContactsRouter.prototype.getContactList = function (req, res, next) {
  * @param {http.ServerResponse} res
  * @param {Function} next
  */
-ContactsRouter.prototype.getContactByNodeID = function (req, res, next) {
+ContactsRouter.prototype.getContactByNodeID = async function (req, res, next) {
   const Contact = this.storage.models.Contact;
 
-  Contact.findOne({ _id: req.params.nodeID }, (err, contact) => {
-    if (err) {
-      return next(new errors.InternalError(err.message));
-    }
+  try {
+    const contact = await Contact.findOne({ _id: req.params.nodeID });
 
     if (!contact) {
       return next(new errors.NotFoundError('Contact not found'));
@@ -288,8 +297,12 @@ ContactsRouter.prototype.getContactByNodeID = function (req, res, next) {
       return res.status(404).send(contact.toObject());
     }
 
-    res.status(200).send(contact.toObject());
-  });
+    return res.status(200).send(contact.toObject());
+  } catch (err) {
+    log.error('[CONTACTS/GET_CONTACT]: Error while getting contact: %s, %s', err.message, err.stack);
+
+    return next(new errors.InternalError(err.message));
+  }
 };
 
 /**


### PR DESCRIPTION
### Contacts routes refactor
We're removing all callbacks from mongoose queries as they are getting deprecated on mongoose 7 and there's not backward compatibility.

### Changes

1. Removed callback from all routes using callbacks along with mongoose queries.
2. Added logs where missing to monitorize any unexpected error.