### PR TITLE
[_] fix(bucket-get-file): remove callback use

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -681,7 +681,7 @@ BucketsRouter.prototype._getRetrievalToken = function (sPointer, opts, done) {
   const self = this;
 
   log.debug('getting retrieval token for %j', sPointer);
-  this.contracts.load(sPointer.hash, function (err, item) {
+  this.contracts.load(sPointer.hash, async function (err, item) {
     if (err) {
       return done(err);
     }
@@ -690,12 +690,10 @@ BucketsRouter.prototype._getRetrievalToken = function (sPointer, opts, done) {
       return opts.excludeFarmers.indexOf(nodeID) === -1;
     });
 
-    self.storage.models.Contact.find({
-      _id: { $in: farmers }
-    }).exec((err, contacts) => {
-      if (err) {
-        return done(err);
-      }
+    try {
+      const contacts = self.storage.models.Contact.find({
+        _id: { $in: farmers }
+      });
 
       let currentTime = Date.now();
       let finalHandlerAlreadyCalled = false;
@@ -751,7 +749,9 @@ BucketsRouter.prototype._getRetrievalToken = function (sPointer, opts, done) {
         self._requestRetrievalPointer.bind(self, item),
         handleResults
       );
-    });
+    } catch (err) {
+      return done(err);
+    }
   });
 };
 /**
@@ -804,7 +804,7 @@ BucketsRouter.prototype._requestRetrievalPointer = function (item, meta, done) {
  * @param {String[]} options.excludeFarmers - Blackisted NodeIDs
  * @param {BucketsRouter~_getPointersFromEntryCallback}
  */
-BucketsRouter.prototype._getPointersFromEntry = function (entry, opts, user, done) {
+BucketsRouter.prototype._getPointersFromEntry = async function (entry, opts, user, done) {
   try {
     const self = this;
     const { Pointer } = this.storage.models;
@@ -817,25 +817,20 @@ BucketsRouter.prototype._getPointersFromEntry = function (entry, opts, user, don
       }
     };
     let pSort = { index: 1 };
-    let cursor = Pointer.find(pQuery).sort(pSort);
+    let pointers = await Pointer.find(pQuery).sort(pSort);
 
-    cursor.exec(function (err, pointers) {
+    async.mapLimit(pointers, 10, function (sPointer, next) {
+      self._getRetrievalToken(sPointer, {
+        excludeFarmers: opts.excludeFarmers
+      }, next);
+    }, function (err, results) {
       if (err) {
         return done(new errors.InternalError(err.message));
       }
 
-      async.mapLimit(pointers, 10, function (sPointer, next) {
-        self._getRetrievalToken(sPointer, {
-          excludeFarmers: opts.excludeFarmers
-        }, next);
-      }, function (err, results) {
-        if (err) {
-          return done(new errors.InternalError(err.message));
-        }
-
-        done(null, results);
-      });
+      done(null, results);
     });
+
   } catch (err) {
     log.error('Error getting pointers from entry: %s. Entry: %s', err.message, entry._id);
     done(err);
@@ -854,7 +849,7 @@ BucketsRouter.prototype._getPointersFromEntry = function (entry, opts, user, don
  * @param {http.ServerResponse} res
  * @param {Function} next
  */
-BucketsRouter.prototype.getFile = function (req, res, next) {
+BucketsRouter.prototype.getFile = async function (req, res, next) {
   const self = this;
   const { Bucket, BucketEntry, User } = self.storage.models;
 
@@ -868,68 +863,62 @@ BucketsRouter.prototype.getFile = function (req, res, next) {
     }
   }
 
-  Bucket.findOne(query, function (err, bucket) {
-    if (err) {
-      return next(new errors.InternalError(err.message));
-    }
-
+  try {
+    const bucket = await Bucket.findOne(query);
     if (!bucket) {
       return next(new errors.NotFoundError('Bucket not found'));
     }
 
-    User.findOne({
+    const user = await User.findOne({
       uuid: bucket.toObject().userId
-    }, function (err, user) {
+    });
+
+    if (!user) {
+      return next(new errors.NotFoundError('User not found for bucket'));
+    }
+
+    const entry = await BucketEntry.findOne({
+      _id: req.params.file,
+      bucket: bucket._id
+    }).populate('frame');
+
+    if (!entry) {
+      return next(new errors.NotFoundError('File not found'));
+    }
+
+    self._getPointersFromEntry(entry, {
+      skip: req.query.skip,
+      limit: req.query.limit,
+      excludeFarmers: req.query.exclude ? req.query.exclude.split(',') : []
+    }, user, function (err, result) {
       if (err) {
-        return next(new errors.InternalError(err.message));
+        return next(err);
       }
 
-      if (!user) {
-        return next(new errors.NotFoundError('User not found for bucket'));
-      }
+      Promise.all(result.map(r => {
+        const { hash, farmer } = r;
 
-      BucketEntry.findOne({
-        _id: req.params.file,
-        bucket: bucket._id
-      }).populate('frame').exec(function (err, entry) {
-        if (err) {
-          return next(new errors.InternalError(err.message));
+        if (!farmer || !farmer.nodeID || !farmer.port || !farmer.address) {
+          return r;
         }
 
-        if (!entry) {
-          return next(new errors.NotFoundError('File not found'));
-        }
+        const { address, port } = farmer;
+        const farmerUrl = `http://${address}:${port}/download/link/${hash}`;
+        const headers = { headers: { 'X-TOKEN': r.token } };
 
-        self._getPointersFromEntry(entry, {
-          skip: req.query.skip,
-          limit: req.query.limit,
-          excludeFarmers: req.query.exclude ? req.query.exclude.split(',') : []
-        }, user, function (err, result) {
-          if (err) {
-            return next(err);
-          }
-
-          Promise.all(result.map(r => {
-            const { hash, farmer } = r;
-
-            if (!farmer || !farmer.nodeID || !farmer.port || !farmer.address) {
-              return r;
-            }
-
-            const { address, port } = farmer;
-            const farmerUrl = `http://${address}:${port}/download/link/${hash}`;
-            const headers = { headers: { 'X-TOKEN': r.token } };
-
-            return axios.get(farmerUrl, headers).then(res => ({ ...r, url: res.data.result }));
-          })).then((mirrors) => {
-            res.send(mirrors);
-          }).catch((err) => {
-            next(err);
-          });
-        });
+        return axios.get(farmerUrl, headers).then(res => ({ ...r, url: res.data.result }));
+      })).then((mirrors) => {
+        res.send(mirrors);
+      }).catch((err) => {
+        next(err);
       });
     });
-  });
+
+  } catch (err) {
+    log.error('getFile: Error getting file %s from bucket %s: %s', req.params.file, req.params.id, err.message);
+
+    return next(new errors.InternalError(err.message));
+  }
 };
 
 BucketsRouter.prototype.getFiles = async function (req, res, next) {


### PR DESCRIPTION
This endpoint is not being used right now as it throws error 500 even before the mongoose upgrade, however, the false positive is triggered multiple times in the logs. This PR removes callbacks from the endpoint.

This endpoint was failing with `"error": "Cannot read properties of undefined (reading 'shards')"`. This PR stops using callbacks and the endpoint is still throwing the mentioned error.

Affected endpoint:

- `GET /buckets/:id/files/:file`

Endpoint used currently:
- `GET /buckets/:id/files/:file/info`
