### PR TITLE
[_] deps: updated service models to remove unused bucketEntry indexes

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "redis": "^3.1.0",
     "secp256k1": "^4.0.2",
     "storj-lib": "github:internxt/core#v8.7.3-beta",
-    "storj-mongodb-adapter": "github:internxt/mongodb-adapter#10.0.0-beta",
+    "storj-mongodb-adapter": "github:internxt/mongodb-adapter#10.0.1-beta",
     "storj-service-error-types": "github:internxt/service-error-types",
     "storj-service-middleware": "github:internxt/service-middleware",
     "storj-service-storage-models": "github:internxt/service-storage-models#11.0.1",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "storj-mongodb-adapter": "github:internxt/mongodb-adapter#10.0.0-beta",
     "storj-service-error-types": "github:internxt/service-error-types",
     "storj-service-middleware": "github:internxt/service-middleware",
-    "storj-service-storage-models": "github:internxt/service-storage-models#11.0.0",
+    "storj-service-storage-models": "github:internxt/service-storage-models#11.0.1",
     "stripe": "^8.49.0",
     "through": "^2.3.8",
     "typescript": "^4.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7297,6 +7297,7 @@ statuses@~1.4.0:
     bitcore-lib "=8.25.10"
     bitcore-message JAlbertoGonzalez/bitcore-message
     diglet "^1.0.6"
+    diskusage "^1.1.3"
     express "^4.17.1"
     hdkey "^2.0.1"
     ip littleskunk/node-ip#b1e7ec0cbff9f7841b1584e50339a774363437c0
@@ -7325,13 +7326,13 @@ statuses@~1.4.0:
     semver "^7.3.5"
     through "^2.3.8"
 
-"storj-mongodb-adapter@github:internxt/mongodb-adapter#10.0.0-beta":
+"storj-mongodb-adapter@github:internxt/mongodb-adapter#10.0.1-beta":
   version "10.0.0-beta"
-  resolved "https://codeload.github.com/internxt/mongodb-adapter/tar.gz/26858fb804a2ae40679dda6471fb265727be5ac3"
+  resolved "https://codeload.github.com/internxt/mongodb-adapter/tar.gz/92a310da95d28d0f0e6368e665475d5062da654c"
   dependencies:
     mongoose "^7.8.7"
     storj-lib "github:internxt/core#v8.7.3-beta"
-    storj-service-storage-models "github:internxt/service-storage-models#11.0.0"
+    storj-service-storage-models "github:internxt/service-storage-models#11.0.1"
 
 "storj-service-error-types@github:internxt/service-error-types":
   version "1.5.0"
@@ -7348,30 +7349,6 @@ statuses@~1.4.0:
     redis "^3.1.0"
     secp256k1 "^4.0.0"
     storj-service-error-types "github:internxt/service-error-types"
-
-"storj-service-storage-models@github:internxt/service-storage-models#11.0.0":
-  version "11.0.0"
-  resolved "https://codeload.github.com/internxt/service-storage-models/tar.gz/f854e41776114280eeb92fe860ef55ce3ce00202"
-  dependencies:
-    bluebird "^3.4.7"
-    coinpayments "^2.1.1"
-    cross-env "^7.0.2"
-    dotenv "^8.2.0"
-    elliptic "^6.3.2"
-    hat "0.0.3"
-    merge "^2.1.1"
-    mime-db "^1.24.0"
-    moment "^2.17.1"
-    mongoose "^7.8.7"
-    mongoose-int32 "^0.1.0"
-    mongoose-types "^1.0.3"
-    ms "^2.1.3"
-    proxyquire "^1.8.0"
-    random-word "^2.0.0"
-    storj-lib "github:internxt/core#v8.7.3-beta"
-    storj-service-error-types "github:internxt/service-error-types"
-    stripe "^8.142.0"
-    uuid "^8.3.2"
 
 "storj-service-storage-models@github:internxt/service-storage-models#11.0.1":
   version "11.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7373,6 +7373,30 @@ statuses@~1.4.0:
     stripe "^8.142.0"
     uuid "^8.3.2"
 
+"storj-service-storage-models@github:internxt/service-storage-models#11.0.1":
+  version "11.0.1"
+  resolved "https://codeload.github.com/internxt/service-storage-models/tar.gz/431719289176830d7ecf6c216c555cdb7694a7ac"
+  dependencies:
+    bluebird "^3.4.7"
+    coinpayments "^2.1.1"
+    cross-env "^7.0.2"
+    dotenv "^8.2.0"
+    elliptic "^6.3.2"
+    hat "0.0.3"
+    merge "^2.1.1"
+    mime-db "^1.24.0"
+    moment "^2.17.1"
+    mongoose "^7.8.7"
+    mongoose-int32 "^0.1.0"
+    mongoose-types "^1.0.3"
+    ms "^2.1.3"
+    proxyquire "^1.8.0"
+    random-word "^2.0.0"
+    storj-lib "github:internxt/core#v8.7.3-beta"
+    storj-service-error-types "github:internxt/service-error-types"
+    stripe "^8.142.0"
+    uuid "^8.3.2"
+
 stream-transform@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/stream-transform/-/stream-transform-2.1.3.tgz#a1c3ecd72ddbf500aa8d342b0b9df38f5aa598e3"


### PR DESCRIPTION
### Changes

1. Updated storage-service-models. https://github.com/internxt/service-storage-models/tree/11.0.1
2. Updated mongodb-adapter as it uses storage-service-models as a dependency. https://github.com/internxt/mongodb-adapter/tree/10.0.1-beta