### PR TITLE
[IN-122]: fix/remove-last-message-enqueueing

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -137,14 +137,6 @@ Engine.prototype.start = function (callback) {
   });
   this.redis.on('error', (err) => {
     log.error('error connecting to redis', err);
-  });
-  this.networkQueue
-    .connectAndRetry()
-    .then(() => {
-      log.info('connected to worker queue');
-    })
-    .catch((err) => {
-      log.error('error connecting to worker queue: %s', err.message);
     });
 
   this.server = new Server(this._config.server, this._configureApp());

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -37,6 +37,7 @@ const { MongoDBTokensRepository } = require('../../core/tokens/MongoDBTokensRepo
 const { MongoDBContactsRepository } = require('../../core/contacts/MongoDBContactsRepository');
 const { MongoDBFileStateRepository } = require('../../core/fileState/MongoDBFileStateRepository');
 const { FileStateUsecase } = require('../../core/fileState/usecase');
+const { getQueue } = require('../../core/queue/bullQueue');
 
 /**
  * Handles endpoints for all bucket and file related operations
@@ -1065,19 +1066,21 @@ BucketsRouter.prototype.deletePointers = async function (pointers) {
 
       const url = `http://${address}:${port}/shards/${hash}`;
 
-      this.networkQueue.enqueueMessage({
-        type: DELETING_FILE_MESSAGE,
-        payload: { key: hash, hash, url }
-      }, (err) => {
-        if (err) {
-          log.error(
-            'deletePointers: Error enqueueing pointer %s shard %s deletion task: %s',
-            pointerId,
-            shard,
-            err.message
-          );
+      try {
+        const q = getQueue();
+        if (!q) {
+          console.error('deletePointers: BullMQ queue not initialized, skipping enqueue for pointer shard %s', hash);
+        } else {
+          q.add('delete-shard', { key: hash, hash, url }, {
+            attempts: 3,
+            backoff: { type: 'exponential', delay: 1000 },
+          }).catch((err) => {
+            console.error('deletePointers: Error enqueuing BullMQ job for pointer shard %s: %s', hash, err.message);
+          });
         }
-      });
+      } catch (err) {
+        console.error('deletePointers: Failed to enqueue BullMQ job for pointer shard %s: %s', hash, err.message);
+        }
     }
 
     pointer.deleteOne().catch((err) => {


### PR DESCRIPTION
## What 

I thought I removed each place where messages are being enqueued, but not the case. In this PR I finally remove those places and disable the queue (although I do not remove everything as the injection and other places are too many points of conflict considering other pending tasks). 

## Why

Checking Grafana I realised we are still enqueuing messages to the RabbitMQ instance we want to replace:
<img width="787" height="192" alt="image" src="https://github.com/user-attachments/assets/6a68a291-ee4e-4123-90c9-8cbc99d2bb44" />
<img width="794" height="410" alt="image" src="https://github.com/user-attachments/assets/becc9b3e-f442-4b43-b4c0-eb72809778e6" />

And this is the last place where message enqueuing is happening. 