### PR TITLE
chore: fix development environment dockerfile

### DIFF
--- a/infrastructure/development.Dockerfile
+++ b/infrastructure/development.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-slim
+FROM node:16-bullseye-slim
 
 # Create a non-root user
 RUN groupadd -r myuser && useradd -r -g myuser myuser -d /app

--- a/infrastructure/preview.Dockerfile
+++ b/infrastructure/preview.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-slim
+FROM node:16-bullseye-slim
 
 # Create a non-root user
 RUN groupadd -r myuser && useradd -r -g myuser myuser -d /app


### PR DESCRIPTION
The previous image didn't work as the repositories' mirrors seems to be removed. This PR just aligns the development images with the images we use on prod.


<img width="1341" height="735" alt="image" src="https://github.com/user-attachments/assets/2714a694-c322-470c-a09d-6c078d286130" />
