### PR TITLE
chore: json log format and append version 

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -41,36 +41,41 @@ const logLevel = process.env.NODE_ENV === 'test'
   ? CONSTANTS.LOG_LEVEL_NONE
   : process.env.LOG_LEVEL || config.logger.level;
 
-module.exports = (() => {
-  const isDev = process.env.NODE_ENV === 'development';
-  const format = isDev ?
-    Winston.format.combine(
-      Winston.format.colorize({ all: true }),
-      Winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-      Winston.format.splat(),
-      Winston.format.printf(info => {
-        const { requestId, clientId } = getContext();
+const injectContext = Winston.format((info) => {
+  const { requestId, clientId, version } = getContext();
+  info.requestId = requestId || null;
+  info.clientId = clientId || null;
+  info.version = version || null;
 
-        return `${info.timestamp} ${info.level} [${requestId || '-'}] [${clientId || '-'}]: ${info.message}`;
-      })
-    ) :
-    Winston.format.combine(
-      Winston.format.splat(),
-      Winston.format.printf(info => {
-        const { requestId, clientId } = getContext();
+  return info;
+});
 
-        return `[${requestId || '-'}] [${clientId || '-'}] ${info.message}`;
-      })
-    );
+const devFormat = Winston.format.combine(
+  Winston.format.colorize({ all: true }),
+  Winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+  Winston.format.splat(),
+  injectContext(),
+  Winston.format.printf(info => {
+    const ctx = [info.requestId, info.clientId, info.version]
+      .map(v => v || '-')
+      .join(' | ');
 
-  return Winston.createLogger(
-    {
-      level: logLevelName(logLevel),
-      levels: myCustomLevels.levels,
-      format,
-      transports: [
-        new Winston.transports.Console()
-      ]
-    }
-  );
-})();
+    return `${info.timestamp} ${info.level} [${ctx}] ${info.message}`;
+  })
+);
+
+const prodFormat = Winston.format.combine(
+  Winston.format.timestamp(),
+  Winston.format.splat(),
+  injectContext(),
+  Winston.format.json()
+);
+
+module.exports = Winston.createLogger({
+  level: logLevelName(logLevel),
+  levels: myCustomLevels.levels,
+  format: process.env.NODE_ENV === 'development' ? devFormat : prodFormat,
+  transports: [
+    new Winston.transports.Console()
+  ]
+});

--- a/lib/requestContext.ts
+++ b/lib/requestContext.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from 'async_hooks';
 interface RequestContext {
   requestId: string;
   clientId: string | undefined;
+  version: string | undefined;
 }
 
 const store = new AsyncLocalStorage<RequestContext>();

--- a/lib/server/middleware/requestLogger.ts
+++ b/lib/server/middleware/requestLogger.ts
@@ -15,6 +15,7 @@ export function requestLogger(req: Request, res: Response, next: NextFunction): 
   const ctx = {
     requestId: uuidv4(),
     clientId: req.headers['internxt-client'] as string | undefined,
+    version: req.headers['internxt-version'] as string | undefined,
   };
 
   requestContextStore.run(ctx, () => {


### PR DESCRIPTION
## Changes
- Added JSON format for prod
- Append client version to logs

new format
```json
{"clientId":"drive-web","level":"info","message":"POST /v2/buckets/69b9373bf8a7af9883d4cf09/files/finish [CLOSED] 200 240.904 ms","requestId":"81f407de-8a67-4d5c-8c8c-e0410a10472a","timestamp":"2026-03-18T13:23:16.236Z","version":"1.0"}

```