### PR TITLE
[IN-115] chore: validate file size check for linux >= v2.5.4

### DIFF
--- a/lib/core/buckets/helpers/uploadValidation.ts
+++ b/lib/core/buckets/helpers/uploadValidation.ts
@@ -4,8 +4,7 @@ import { getContext } from "../../../requestContext";
 const EXEMPT_CLIENTS: Record<string, string> = {
     "internxt-cli": "1.6.3",
     "drive-desktop-windows": "2.6.6",
-    // All versions
-    "drive-desktop-linux": '*',
+    "drive-desktop-linux": '2.5.3',
 };
 
 export function shouldEnforceUploadValidation(): boolean {

--- a/tests/lib/core/buckets/helpers/uploadValidation.test.ts
+++ b/tests/lib/core/buckets/helpers/uploadValidation.test.ts
@@ -34,15 +34,20 @@ describe('shouldEnforceUploadValidation()', () => {
     });
   });
 
-  describe('When the client is drive-desktop-linux (all versions exempt)', () => {
-    it('When called with any version, then it should not enforce', () => {
-      mockContext('drive-desktop-linux', '0.0.1');
+  describe('When the client is drive-desktop-linux (exempt up to 2.5.3)', () => {
+    it('When version is below the exempt threshold, then it should not enforce', () => {
+      mockContext('drive-desktop-linux', '2.5.2');
       expect(shouldEnforceUploadValidation()).toBe(false);
     });
 
-    it('When called with a high version, then it should not enforce', () => {
-      mockContext('drive-desktop-linux', '99.99.99');
+    it('When version equals the exempt threshold, then it should not enforce', () => {
+      mockContext('drive-desktop-linux', '2.5.3');
       expect(shouldEnforceUploadValidation()).toBe(false);
+    });
+
+    it('When version is above the exempt threshold, then it should enforce', () => {
+      mockContext('drive-desktop-linux', '2.5.4');
+      expect(shouldEnforceUploadValidation()).toBe(true);
     });
   });
 


### PR DESCRIPTION
Linux is using the fixed inxt-js version starting from v2.5.4, so all prior versions should be exempt from the file size check.